### PR TITLE
modify sorting size

### DIFF
--- a/Problem2/src/sorting.c
+++ b/Problem2/src/sorting.c
@@ -11,7 +11,7 @@
 #include "xgpio.h"
 #include "xil_printf.h"
 
-#define SIZE 5
+#define SIZE 20 
 #define SW_DEVICE_ID  XPAR_GPIO_0_DEVICE_ID
 
 XGpio SW_Gpio;


### PR DESCRIPTION
The sorting SIZE should be 20, SIZE 5 is just for testing. Sorry for making the mistake.

Also, For the 2nd issue from https://github.com/yuyuranium/fpga-hw3/pull/2#discussion_r854805379, the additional `printf` is needed. What user typed won't be shown on PuTTY terminal, however, i can't tell the reason. A printf-removed test is taken.
![image](https://user-images.githubusercontent.com/48234255/164422587-15f7e4f2-377a-444b-8e6c-25f9ee21922d.png)
