### PR TITLE
Fix sort not correct second time

### DIFF
--- a/Problem3/src/sort.v
+++ b/Problem3/src/sort.v
@@ -120,7 +120,20 @@ module sort (
         cnt_arr[8 * i + 7] <= 5'd0;
       end
     end else begin
-      cnt_arr[pos] <= cnt_arr_d;
+      if (state_q != `DONE) begin
+        cnt_arr[pos] <= cnt_arr_d;
+      end else begin
+        for (i = 0; i < 32; i = i + 1) begin
+          cnt_arr[8 * i]     <= 5'd0;
+          cnt_arr[8 * i + 1] <= 5'd0;
+          cnt_arr[8 * i + 2] <= 5'd0;
+          cnt_arr[8 * i + 3] <= 5'd0;
+          cnt_arr[8 * i + 4] <= 5'd0;
+          cnt_arr[8 * i + 5] <= 5'd0;
+          cnt_arr[8 * i + 6] <= 5'd0;
+          cnt_arr[8 * i + 7] <= 5'd0;
+        end
+      end
     end
   end
 

--- a/Problem3/src/tb.cc
+++ b/Problem3/src/tb.cc
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
   unsigned char opd1, opd2, op = 0;
   srand(time(nullptr));
 
-  int posedge_cnt = 0;
-  while (!contextp->gotFinish() && posedge_cnt < 500) {
+  int posedge_cnt = 0, sort_cnt = 0;
+  while (!contextp->gotFinish() && posedge_cnt < 600) {
     top->rst_ni = 1;
     if (contextp->time() >= 3 && contextp->time() < 5) {
       top->rst_ni = 0;
@@ -121,6 +121,14 @@ int main(int argc, char *argv[])
       default:
         top->wr_en_i = 0;
         top->data_i = 0;
+        if (posedge_cnt > 25 && sort_cnt < 2) {
+          top->addr_i = 0x10000000;
+          if (top->data_o == 0) {
+            cout << "sort again" << endl;
+            sort_cnt++;
+            posedge_cnt = 19;
+          }
+        }
         break;
       }
     }


### PR DESCRIPTION
I revised the `sort.v` so it clear the counter array `cnt_arr` after state machine transitioned to `DONE` state. The following waveform shows the result of consecutively doing sorting 3 times. Now it works correctly. Please take a look!

![Screenshot from 2022-04-26 22-40-32](https://user-images.githubusercontent.com/79467307/165325974-c2dd9f2e-d806-4456-84ca-a14d8aa9c568.png)