### PR TITLE
Fix sort not correct second time and re-package ip

### DIFF
--- a/Problem3/ip_repo/p3_2_sort_1.0/component.xml
+++ b/Problem3/ip_repo/p3_2_sort_1.0/component.xml
@@ -266,7 +266,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>2534a70a</spirit:value>
+            <spirit:value>567c9c14</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -282,7 +282,7 @@
         <spirit:parameters>
           <spirit:parameter>
             <spirit:name>viewChecksum</spirit:name>
-            <spirit:value>2534a70a</spirit:value>
+            <spirit:value>567c9c14</spirit:value>
           </spirit:parameter>
         </spirit:parameters>
       </spirit:view>
@@ -814,32 +814,29 @@
       </xilinx:taxonomies>
       <xilinx:displayName>p3_2_sort_v1.0</xilinx:displayName>
       <xilinx:coreRevision>2</xilinx:coreRevision>
-      <xilinx:coreCreationDateTime>2022-04-26T03:47:23Z</xilinx:coreCreationDateTime>
+      <xilinx:coreCreationDateTime>2022-04-26T15:18:06Z</xilinx:coreCreationDateTime>
       <xilinx:tags>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@5b0dae8b_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@4adea4a6_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@29108377_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@1082bd61_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@4d5eeea1_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@bf52d5a_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@5342ca81_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@2b0f2afa_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@e36f346_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@67a06ac4_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@77179c9a_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@5d96c2b6_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@5fa31230_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@143fc040_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@db8d4bc_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@14718f01_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
-        <xilinx:tag xilinx:name="ui.data.coregen.dd@2fcdf580_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2a29ffb7_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@6116ccc7_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@18650b4_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@74be8547_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7c87276e_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@5f7c30e3_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@368db586_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@20e20c7a_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@2ead8575_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7472e3cc_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@7bcd98c4_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@3d80a4c2_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@1fce82be_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
+        <xilinx:tag xilinx:name="ui.data.coregen.dd@20397f67_ARCHIVE_LOCATION">c:/Users/u4m61/Desktop/FPGA/hw3/ip_repo/p3_2_sort_1.0</xilinx:tag>
       </xilinx:tags>
     </xilinx:coreExtensions>
     <xilinx:packagingInfo>
       <xilinx:xilinxVersion>2020.2</xilinx:xilinxVersion>
       <xilinx:checksum xilinx:scope="busInterfaces" xilinx:value="0a865c66"/>
       <xilinx:checksum xilinx:scope="memoryMaps" xilinx:value="ed1368d5"/>
-      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="65e56b97"/>
+      <xilinx:checksum xilinx:scope="fileGroups" xilinx:value="69c6877a"/>
       <xilinx:checksum xilinx:scope="ports" xilinx:value="68cee0a1"/>
       <xilinx:checksum xilinx:scope="hdlParameters" xilinx:value="e7b50784"/>
       <xilinx:checksum xilinx:scope="parameters" xilinx:value="3f86c751"/>

--- a/Problem3/ip_repo/p3_2_sort_1.0/drivers/p3_2_sort_v1_0/src/p3_2_sort.c
+++ b/Problem3/ip_repo/p3_2_sort_1.0/drivers/p3_2_sort_v1_0/src/p3_2_sort.c
@@ -3,24 +3,4 @@
 /***************************** Include Files *******************************/
 #include "p3_2_sort.h"
 
-/* My thought on the driver code, feel free to remove these comments once done -- by yuyuranium */
-/* void sort(unsigned char *arr)
- * {
- *   loop i = 1 ~ 4:
- *     assemble 4 elements in arr into a u32
- *     write the u32 to the memory-mapped register[i] via AXI 
- *   write 1 to reg0
- *
- *   while (reg0 == 1):
- *     read reg0
- *
- *   loop i = 1 ~ 4:
- *     retrieve u32 data via AXI and store to temp
- *     loop j = 1 ~ 4:
- *       arr[i * 4 + j] = temp & 0xff
- *       temp = temp >> 8
- * }
- *
- */
-
 /************************** Function Definitions ***************************/

--- a/Problem3/ip_repo/p3_2_sort_1.0/hdl/p3_2_sort_v1_0_S00_AXI.v
+++ b/Problem3/ip_repo/p3_2_sort_1.0/hdl/p3_2_sort_v1_0_S00_AXI.v
@@ -236,7 +236,7 @@
 	      slv_reg8 <= 0;
 	    end 
 	  else begin
-        case ( axi_awaddr[ADDR_LSB+OPT_MEM_ADDR_BITS:ADDR_LSB] )
+	    case ( axi_awaddr[ADDR_LSB+OPT_MEM_ADDR_BITS:ADDR_LSB] )
           4'h0: begin
             if (!busy) begin  // not busy, allow input when slv_reg_wren
                 if (slv_reg_wren)

--- a/Problem3/ip_repo/p3_2_sort_1.0/src/sort.v
+++ b/Problem3/ip_repo/p3_2_sort_1.0/src/sort.v
@@ -120,7 +120,20 @@ module sort (
         cnt_arr[8 * i + 7] <= 5'd0;
       end
     end else begin
-      cnt_arr[pos] <= cnt_arr_d;
+      if (state_q != `DONE) begin
+        cnt_arr[pos] <= cnt_arr_d;
+      end else begin
+        for (i = 0; i < 32; i = i + 1) begin
+          cnt_arr[8 * i]     <= 5'd0;
+          cnt_arr[8 * i + 1] <= 5'd0;
+          cnt_arr[8 * i + 2] <= 5'd0;
+          cnt_arr[8 * i + 3] <= 5'd0;
+          cnt_arr[8 * i + 4] <= 5'd0;
+          cnt_arr[8 * i + 5] <= 5'd0;
+          cnt_arr[8 * i + 6] <= 5'd0;
+          cnt_arr[8 * i + 7] <= 5'd0;
+        end
+      end
     end
   end
 

--- a/Problem3/src/sort.v
+++ b/Problem3/src/sort.v
@@ -120,7 +120,20 @@ module sort (
         cnt_arr[8 * i + 7] <= 5'd0;
       end
     end else begin
-      cnt_arr[pos] <= cnt_arr_d;
+      if (state_q != `DONE) begin
+        cnt_arr[pos] <= cnt_arr_d;
+      end else begin
+        for (i = 0; i < 32; i = i + 1) begin
+          cnt_arr[8 * i]     <= 5'd0;
+          cnt_arr[8 * i + 1] <= 5'd0;
+          cnt_arr[8 * i + 2] <= 5'd0;
+          cnt_arr[8 * i + 3] <= 5'd0;
+          cnt_arr[8 * i + 4] <= 5'd0;
+          cnt_arr[8 * i + 5] <= 5'd0;
+          cnt_arr[8 * i + 6] <= 5'd0;
+          cnt_arr[8 * i + 7] <= 5'd0;
+        end
+      end
     end
   end
 

--- a/Problem3/src/tb.cc
+++ b/Problem3/src/tb.cc
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
   unsigned char opd1, opd2, op = 0;
   srand(time(nullptr));
 
-  int posedge_cnt = 0;
-  while (!contextp->gotFinish() && posedge_cnt < 500) {
+  int posedge_cnt = 0, sort_cnt = 0;
+  while (!contextp->gotFinish() && posedge_cnt < 600) {
     top->rst_ni = 1;
     if (contextp->time() >= 3 && contextp->time() < 5) {
       top->rst_ni = 0;
@@ -121,6 +121,14 @@ int main(int argc, char *argv[])
       default:
         top->wr_en_i = 0;
         top->data_i = 0;
+        if (posedge_cnt > 25 && sort_cnt < 2) {
+          top->addr_i = 0x10000000;
+          if (top->data_o == 0) {
+            cout << "sort again" << endl;
+            sort_cnt++;
+            posedge_cnt = 19;
+          }
+        }
         break;
       }
     }


### PR DESCRIPTION
I revised the `sort.v` so it clear the counter array `cnt_arr` after state machine transitioned to `DONE` state. The following waveform shows the result of consecutively doing sorting 3 times. Now it works correctly. Also, IP is re-packaged. Please take a look!

![image](https://user-images.githubusercontent.com/79467307/165335705-d52e7352-13dc-4d37-ad9d-042eb05b18d8.png)

**Note that this PR is going to be merged into @WillyChennnn 's branch**